### PR TITLE
Fix Hisha equality check to ignore spaces altogether

### DIFF
--- a/core/notification/app/bin/hisha.py
+++ b/core/notification/app/bin/hisha.py
@@ -255,8 +255,8 @@ class Hisha:
 
         try:
             # Anilist sometimes has weird leading/trailing spaces in the show names
-            re_str1 = re.sub(r'[^\w\s]','', str1).strip()
-            re_str2 = re.sub(r'[^\w\s]','', str2).strip()
+            re_str1 = re.sub(r'[^\w]','', str1)
+            re_str2 = re.sub(r'[^\w]','', str2)
             return bool(re_str1 == re_str2)
         except:
             return False

--- a/core/notification/app/bin/hisha.py
+++ b/core/notification/app/bin/hisha.py
@@ -254,8 +254,9 @@ class Hisha:
         self._logger.debug("Comparing {} and {} without punctuation".format(str1, str2))
 
         try:
-            re_str1 = re.sub(r'[^\w\s]','', str1)
-            re_str2 = re.sub(r'[^\w\s]','', str2)
+            # Anilist sometimes has weird leading/trailing spaces in the show names
+            re_str1 = re.sub(r'[^\w\s]','', str1).strip()
+            re_str2 = re.sub(r'[^\w\s]','', str2).strip()
             return bool(re_str1 == re_str2)
         except:
             return False

--- a/modules/hisha/hisha.py
+++ b/modules/hisha/hisha.py
@@ -245,8 +245,9 @@ class Hisha:
         self._logger.debug("Comparing {} and {} without punctuation".format(str1, str2))
 
         try:
-            re_str1 = re.sub(r'[^\w\s]','', str1)
-            re_str2 = re.sub(r'[^\w\s]','', str2)
+            # Anilist sometimes has weird leading/trailing spaces
+            re_str1 = re.sub(r'[^\w\s]','', str1).strip()
+            re_str2 = re.sub(r'[^\w\s]','', str2).strip()
             return bool(re_str1 == re_str2)
         except:
             return False

--- a/modules/hisha/hisha.py
+++ b/modules/hisha/hisha.py
@@ -246,8 +246,8 @@ class Hisha:
 
         try:
             # Anilist sometimes has weird leading/trailing spaces
-            re_str1 = re.sub(r'[^\w\s]','', str1).strip()
-            re_str2 = re.sub(r'[^\w\s]','', str2).strip()
+            re_str1 = re.sub(r'[^\w]','', str1)
+            re_str2 = re.sub(r'[^\w]','', str2)
             return bool(re_str1 == re_str2)
         except:
             return False


### PR DESCRIPTION
Now regex equality checking ignores spaces, because Acquisition's automatic name cleaning will create extra spaces